### PR TITLE
Restrict checkpoint download script to large model

### DIFF
--- a/checkpoints/download_ckpts.sh
+++ b/checkpoints/download_ckpts.sh
@@ -16,44 +16,12 @@ else
     exit 1
 fi
 
-# Define the URLs for SAM 2 checkpoints
-# SAM2_BASE_URL="https://dl.fbaipublicfiles.com/segment_anything_2/072824"
-# sam2_hiera_t_url="${SAM2_BASE_URL}/sam2_hiera_tiny.pt"
-# sam2_hiera_s_url="${SAM2_BASE_URL}/sam2_hiera_small.pt"
-# sam2_hiera_b_plus_url="${SAM2_BASE_URL}/sam2_hiera_base_plus.pt"
-# sam2_hiera_l_url="${SAM2_BASE_URL}/sam2_hiera_large.pt"
-
-# Download each of the four checkpoints using wget
-# echo "Downloading sam2_hiera_tiny.pt checkpoint..."
-# $CMD $sam2_hiera_t_url || { echo "Failed to download checkpoint from $sam2_hiera_t_url"; exit 1; }
-
-# echo "Downloading sam2_hiera_small.pt checkpoint..."
-# $CMD $sam2_hiera_s_url || { echo "Failed to download checkpoint from $sam2_hiera_s_url"; exit 1; }
-
-# echo "Downloading sam2_hiera_base_plus.pt checkpoint..."
-# $CMD $sam2_hiera_b_plus_url || { echo "Failed to download checkpoint from $sam2_hiera_b_plus_url"; exit 1; }
-
-# echo "Downloading sam2_hiera_large.pt checkpoint..."
-# $CMD $sam2_hiera_l_url || { echo "Failed to download checkpoint from $sam2_hiera_l_url"; exit 1; }
-
-# Define the URLs for SAM 2.1 checkpoints
+## Define the URL for the SAM 2.1 large checkpoint
 SAM2p1_BASE_URL="https://dl.fbaipublicfiles.com/segment_anything_2/092824"
-sam2p1_hiera_t_url="${SAM2p1_BASE_URL}/sam2.1_hiera_tiny.pt"
-sam2p1_hiera_s_url="${SAM2p1_BASE_URL}/sam2.1_hiera_small.pt"
-sam2p1_hiera_b_plus_url="${SAM2p1_BASE_URL}/sam2.1_hiera_base_plus.pt"
 sam2p1_hiera_l_url="${SAM2p1_BASE_URL}/sam2.1_hiera_large.pt"
 
-# SAM 2.1 checkpoints
-echo "Downloading sam2.1_hiera_tiny.pt checkpoint..."
-$CMD $sam2p1_hiera_t_url || { echo "Failed to download checkpoint from $sam2p1_hiera_t_url"; exit 1; }
-
-echo "Downloading sam2.1_hiera_small.pt checkpoint..."
-$CMD $sam2p1_hiera_s_url || { echo "Failed to download checkpoint from $sam2p1_hiera_s_url"; exit 1; }
-
-echo "Downloading sam2.1_hiera_base_plus.pt checkpoint..."
-$CMD $sam2p1_hiera_b_plus_url || { echo "Failed to download checkpoint from $sam2p1_hiera_b_plus_url"; exit 1; }
-
+## Download the SAM 2.1 large checkpoint
 echo "Downloading sam2.1_hiera_large.pt checkpoint..."
 $CMD $sam2p1_hiera_l_url || { echo "Failed to download checkpoint from $sam2p1_hiera_l_url"; exit 1; }
 
-echo "All checkpoints are downloaded successfully."
+echo "Checkpoint downloaded successfully."


### PR DESCRIPTION
## Summary
- simplify checkpoint downloader to fetch only the SAM 2.1 large model

## Testing
- `bash -n checkpoints/download_ckpts.sh`


------
https://chatgpt.com/codex/tasks/task_e_6892433b236083219628a0eccac2abad